### PR TITLE
Improved type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,6 @@ source = ["tfin"]
 
 [tool.coverage.report]
 show_missing = true
+
+[tool.mypy]
+check_untyped_defs = true

--- a/tfin/accounting/chart_of_accounts.py
+++ b/tfin/accounting/chart_of_accounts.py
@@ -1,6 +1,6 @@
 from .types import N
 from .enums import AccountType
-from .core import Account, Asset, Liability, Income, Expense, Equity, accounts_by_type
+from .core import Account, Asset, Liability, Income, Expense, Equity, accounts_by_type, AccountTypes
 
 class ChartOfAccounts:
     """A chart of accounts that can manage and filter accounts"""
@@ -47,7 +47,7 @@ class ChartOfAccounts:
         if accounts and account.name in accounts:
             del self._accounts[account.account_type.name][account.name]
 
-    def _create_account(self, acc_cls: Account, name: str, balance: float = 0.0):
+    def _create_account(self, acc_cls: type[AccountTypes], name: str, balance: float = 0.0):
         account = acc_cls(name, balance)
         self.add_account(account)
         return account
@@ -84,7 +84,8 @@ class ChartOfAccounts:
         if not cast_account_type:
             return None
 
-        account = accounts_by_type[cast_account_type](
+        account_cls = accounts_by_type[cast_account_type]
+        account = account_cls(
             name=account_name, starting_balance=float(starting_balance)
         )
         self.add_account(account)

--- a/tfin/accounting/core.py
+++ b/tfin/accounting/core.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from .types import N, C
+from collections.abc import Callable
+from .types import N
 from .enums import AccountType
 
 @dataclass
@@ -19,27 +20,32 @@ class AccountBase:
     def set_balance(self, amount: N):
         self._balance = float(amount)
 
-    def __str__(self):
-        return f"{self.name}[{self.account_type.name} - ${self.balance:.2f}]"
-    
+   
+type NumericOp = Callable[[float], float]
+
 class Account(AccountBase):
     """Account abstract dataclass.
 
     Do not instantiate directly.  It is useful, however, as a typing reference and
     for isinstance() checks"""
 
-    debit_op: C
-    credit_op: C
+    debit_op: NumericOp
+    credit_op: NumericOp
+    
     account_type: AccountType
 
     def debit(self, amount: N):
         """Debit the account by an amount."""
-        self.set_balance(self.__class__.debit_op(self.balance, float(amount)))
+        # TODO: Fix the typing issue on refactor
+        self.set_balance(self.__class__.debit_op(self.balance, float(amount)))  # type: ignore
 
     def credit(self, amount: N):
         """Credit the account by an amount"""
-        self.set_balance(self.__class__.credit_op(self.balance, float(amount)))
+        # TODO: Fix the typing issue on refactor
+        self.set_balance(self.__class__.credit_op(self.balance, float(amount))) # type: ignore
 
+    def __str__(self):
+        return f"{self.name}[{self.account_type.name} - ${self.balance:.2f}]"
 
 class AssetLike:
     """Mixin to manage the asset like accounts wrt to the operation of debit and credit"""
@@ -84,8 +90,9 @@ class Expense(Account, AssetLike):
 
     account_type = AccountType.EXPENSE
 
+AccountTypes = Asset | Liability | Equity | Income | Expense
 
-accounts_by_type: dict[AccountType, Account] = {
+accounts_by_type: dict[AccountType, type[Account]] = {
     AccountType.ASSET: Asset,
     AccountType.LIABILITY: Liability,
     AccountType.EQUITY: Equity,

--- a/tfin/accounting/transactions.py
+++ b/tfin/accounting/transactions.py
@@ -56,7 +56,7 @@ class Transaction(Event):
         """A float property of the total amount of credits in the transaction"""
         return sum([i.amount for i in self._credits])
 
-    def add_debit(self, item: Account | TransactionItem, amount: float = None):
+    def add_debit(self, item: Account | TransactionItem, amount: float | None = None):
         """Adds a TransactionItem to the debits"""
         if isinstance(item, Account):
             if amount is None:
@@ -69,7 +69,7 @@ class Transaction(Event):
 
         self._debits.append(trans_item)
 
-    def add_credit(self, item: Account | TransactionItem, amount: float = None):
+    def add_credit(self, item: Account | TransactionItem, amount: float | None = None):
         """Adds a TransactionItem to the credits"""
         if isinstance(item, Account):
             if amount is None:

--- a/tfin/engine/core.py
+++ b/tfin/engine/core.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 import heapq
 
 from .enums import EngineState
-from .event import EventLike
+from .event import Event, EventLike
 from .exceptions import EventError, StopEngineError
 
 @dataclass
@@ -16,7 +16,7 @@ class EngineStatus:
 @dataclass(order=True)
 class QueueItem:
     timestep: int
-    event: EventLike = field(compare=False)
+    event: Event = field(compare=False)
 
 
 @dataclass
@@ -62,10 +62,10 @@ class Engine:
         """Returns whether the current engine state evaluates to the provided one"""
         return self.state == state
 
-    def schedule(self, event: EventLike, timestep: int = None) -> None:
+    def schedule(self, event: Event, timestep: int | None = None) -> None:
         """Schedule an event to the queue"""
 
-        if isinstance(event, EventLike):
+        if isinstance(event, Event):
             timestep = timestep or event.timestep
             heapq.heappush(self.queue, QueueItem(timestep, event))
 
@@ -81,7 +81,7 @@ class Engine:
         """Finish the program"""
         self.set_status(EngineState.FINISHED, msg)
 
-    def run(self, stop_at: int = None) -> None:
+    def run(self, stop_at: int | None = None) -> None:
         """Runs the simulation.
 
         This involves continually retrieving events from the queue until
@@ -110,7 +110,7 @@ class Engine:
             if not self.consume_event(event):
                 return
 
-    def consume_event(self, event: EventLike):
+    def consume_event(self, event: Event):
         """Processes an event, checks for errors and schedules any events that are yielded"""
         try:
             for evt in event.call():
@@ -127,3 +127,5 @@ class Engine:
             )
         else:
             return True
+        
+        return False

--- a/tfin/engine/exceptions.py
+++ b/tfin/engine/exceptions.py
@@ -1,3 +1,4 @@
+from .event import Event
 
 class EngineError(Exception):  # pragma: no cover
     """The simulation encountered an error"""


### PR DESCRIPTION
Closes #6 

`mypy` was not running cleanly before.  It took a little bit of type wrangling and fixes to produce a clean result

An option for `check_untyped_defs=true` was added to the mypy config to suppress a warning that was occurring